### PR TITLE
fix(sec): upgrade io.springfox:springfox-swagger-ui to 2.10.0

### DIFF
--- a/mall-tiny-02/pom.xml
+++ b/mall-tiny-02/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
     </dependencies>
 

--- a/mall-tiny-03/pom.xml
+++ b/mall-tiny-03/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--redis依赖配置-->
         <dependency>

--- a/mall-tiny-04/pom.xml
+++ b/mall-tiny-04/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--redis依赖配置-->
         <dependency>

--- a/mall-tiny-05/pom.xml
+++ b/mall-tiny-05/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--redis依赖配置-->
         <dependency>

--- a/mall-tiny-06/pom.xml
+++ b/mall-tiny-06/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--redis依赖配置-->
         <dependency>

--- a/mall-tiny-07/pom.xml
+++ b/mall-tiny-07/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--redis依赖配置-->
         <dependency>

--- a/mall-tiny-08/pom.xml
+++ b/mall-tiny-08/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--redis依赖配置-->
         <dependency>

--- a/mall-tiny-09/pom.xml
+++ b/mall-tiny-09/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--redis依赖配置-->
         <dependency>

--- a/mall-tiny-aop/pom.xml
+++ b/mall-tiny-aop/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--Hutool Java工具包-->
         <dependency>

--- a/mall-tiny-apm/pom.xml
+++ b/mall-tiny-apm/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--Elastic Agent相关依赖-->
         <dependency>

--- a/mall-tiny-arthas/pom.xml
+++ b/mall-tiny-arthas/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
     </dependencies>
 

--- a/mall-tiny-arthas2/pom.xml
+++ b/mall-tiny-arthas2/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--集成Java诊断利器Arthas-->
         <dependency>

--- a/mall-tiny-delay/pom.xml
+++ b/mall-tiny-delay/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--redis依赖配置-->
         <dependency>

--- a/mall-tiny-devtools/pom.xml
+++ b/mall-tiny-devtools/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-docker-compose/pom.xml
+++ b/mall-tiny-docker-compose/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
     </dependencies>
 

--- a/mall-tiny-docker-file/pom.xml
+++ b/mall-tiny-docker-file/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
     </dependencies>
 

--- a/mall-tiny-docker-plugin/pom.xml
+++ b/mall-tiny-docker-plugin/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
     </dependencies>
 

--- a/mall-tiny-docker/pom.xml
+++ b/mall-tiny-docker/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
     </dependencies>
 

--- a/mall-tiny-dynamic-sql/pom.xml
+++ b/mall-tiny-dynamic-sql/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
     </dependencies>
 

--- a/mall-tiny-elasticsearch/pom.xml
+++ b/mall-tiny-elasticsearch/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--Hutool Java工具包-->
         <dependency>

--- a/mall-tiny-elk/pom.xml
+++ b/mall-tiny-elk/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--Hutool Java工具包-->
         <dependency>

--- a/mall-tiny-fabric/pom.xml
+++ b/mall-tiny-fabric/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
     </dependencies>
 

--- a/mall-tiny-generator/pom.xml
+++ b/mall-tiny-generator/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
     </dependencies>
 

--- a/mall-tiny-grafana/pom.xml
+++ b/mall-tiny-grafana/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-hutool/pom.xml
+++ b/mall-tiny-hutool/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>cn.hutool</groupId>

--- a/mall-tiny-jenkins/pom.xml
+++ b/mall-tiny-jenkins/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
     </dependencies>
 

--- a/mall-tiny-jwt/pom.xml
+++ b/mall-tiny-jwt/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--Hutool Java工具包-->
         <dependency>

--- a/mall-tiny-kafka/pom.xml
+++ b/mall-tiny-kafka/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-log/pom.xml
+++ b/mall-tiny-log/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--Hutool Java工具包-->
         <dependency>

--- a/mall-tiny-loki/pom.xml
+++ b/mall-tiny-loki/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-mqtt/pom.xml
+++ b/mall-tiny-mqtt/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-oss/pom.xml
+++ b/mall-tiny-oss/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--MinIO JAVA SDK-->
         <dependency>

--- a/mall-tiny-plus/pom.xml
+++ b/mall-tiny-plus/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-powerjob/pom.xml
+++ b/mall-tiny-powerjob/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-pulsar/pom.xml
+++ b/mall-tiny-pulsar/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-quartz/pom.xml
+++ b/mall-tiny-quartz/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-rabbit/pom.xml
+++ b/mall-tiny-rabbit/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--hutool工具包-->
         <dependency>

--- a/mall-tiny-redis/pom.xml
+++ b/mall-tiny-redis/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>cn.hutool</groupId>

--- a/mall-tiny-stream/pom.xml
+++ b/mall-tiny-stream/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
     </dependencies>
 

--- a/mall-tiny/pom.xml
+++ b/mall-tiny/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.10.0</version>
         </dependency>
         <!--redis依赖配置-->
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.springfox:springfox-swagger-ui 2.7.0
- [CVE-2019-17495](https://www.oscs1024.com/hd/CVE-2019-17495)


### What did I do？
Upgrade io.springfox:springfox-swagger-ui from 2.7.0 to 2.10.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS