### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/mall-tiny-01/pom.xml
+++ b/mall-tiny-01/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
     </dependencies>
 

--- a/mall-tiny-02/pom.xml
+++ b/mall-tiny-02/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-03/pom.xml
+++ b/mall-tiny-03/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-04/pom.xml
+++ b/mall-tiny-04/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-05/pom.xml
+++ b/mall-tiny-05/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-06/pom.xml
+++ b/mall-tiny-06/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-07/pom.xml
+++ b/mall-tiny-07/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-08/pom.xml
+++ b/mall-tiny-08/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-09/pom.xml
+++ b/mall-tiny-09/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-aop/pom.xml
+++ b/mall-tiny-aop/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-apm/pom.xml
+++ b/mall-tiny-apm/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-arthas/pom.xml
+++ b/mall-tiny-arthas/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-arthas2/pom.xml
+++ b/mall-tiny-arthas2/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-boot/pom.xml
+++ b/mall-tiny-boot/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-delay/pom.xml
+++ b/mall-tiny-delay/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-deploy/pom.xml
+++ b/mall-tiny-deploy/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-devtools/pom.xml
+++ b/mall-tiny-devtools/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-docker-compose/pom.xml
+++ b/mall-tiny-docker-compose/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-docker-file/pom.xml
+++ b/mall-tiny-docker-file/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-docker-plugin/pom.xml
+++ b/mall-tiny-docker-plugin/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-docker/pom.xml
+++ b/mall-tiny-docker/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-drone/pom.xml
+++ b/mall-tiny-drone/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-dynamic-sql/pom.xml
+++ b/mall-tiny-dynamic-sql/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-easyes/pom.xml
+++ b/mall-tiny-easyes/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--springfox swagger官方Starter-->
         <dependency>

--- a/mall-tiny-elasticsearch/pom.xml
+++ b/mall-tiny-elasticsearch/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-elk/pom.xml
+++ b/mall-tiny-elk/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-erupt/pom.xml
+++ b/mall-tiny-erupt/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-fabric/pom.xml
+++ b/mall-tiny-fabric/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-flyway/pom.xml
+++ b/mall-tiny-flyway/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Flyway相关依赖-->
         <dependency>

--- a/mall-tiny-generator/pom.xml
+++ b/mall-tiny-generator/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-gitlab/pom.xml
+++ b/mall-tiny-gitlab/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-grafana/pom.xml
+++ b/mall-tiny-grafana/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-hutool/pom.xml
+++ b/mall-tiny-hutool/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-jenkins/pom.xml
+++ b/mall-tiny-jenkins/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-jwt/pom.xml
+++ b/mall-tiny-jwt/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-keycloak/pom.xml
+++ b/mall-tiny-keycloak/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--springfox swagger官方Starter-->
         <dependency>

--- a/mall-tiny-knife4j/pom.xml
+++ b/mall-tiny-knife4j/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--整合Knife4j-->
         <dependency>

--- a/mall-tiny-log/pom.xml
+++ b/mall-tiny-log/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-loki/pom.xml
+++ b/mall-tiny-loki/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-magic-api/pom.xml
+++ b/mall-tiny-magic-api/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-mybatis/pom.xml
+++ b/mall-tiny-mybatis/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--springfox swagger官方Starter-->
         <dependency>

--- a/mall-tiny-oss/pom.xml
+++ b/mall-tiny-oss/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-powerjob/pom.xml
+++ b/mall-tiny-powerjob/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-quartz/pom.xml
+++ b/mall-tiny-quartz/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-redis/pom.xml
+++ b/mall-tiny-redis/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-sa-token/pom.xml
+++ b/mall-tiny-sa-token/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-security/pom.xml
+++ b/mall-tiny-security/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-smart-doc/pom.xml
+++ b/mall-tiny-smart-doc/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-springdoc/pom.xml
+++ b/mall-tiny-springdoc/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-stream/pom.xml
+++ b/mall-tiny-stream/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>

--- a/mall-tiny-swagger/pom.xml
+++ b/mall-tiny-swagger/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-swagger2/pom.xml
+++ b/mall-tiny-swagger2/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny-test/pom.xml
+++ b/mall-tiny-test/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--springfox swagger官方Starter-->
         <dependency>

--- a/mall-tiny-torna/pom.xml
+++ b/mall-tiny-torna/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--lombok依赖-->
         <dependency>

--- a/mall-tiny/pom.xml
+++ b/mall-tiny/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!--Swagger-UI API文档生产工具-->
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in mysql:mysql-connector-java 8.0.15
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)


### What did I do？
Upgrade mysql:mysql-connector-java from 8.0.15 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS